### PR TITLE
Fix: TopBar mobile adjusts and fixes

### DIFF
--- a/src/components/TopBar/index.tsx
+++ b/src/components/TopBar/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import * as S from './styles'
@@ -10,6 +10,8 @@ const TopBar = () => {
   const clickOpenMenu = () => {
     setIsOpenMenu(prevState => !prevState)
   }
+
+  useEffect(() => setIsOpenMenu(false), [router])
 
   return (
     <S.Wrapper as="header">

--- a/src/components/TopBar/styles.ts
+++ b/src/components/TopBar/styles.ts
@@ -72,7 +72,7 @@ export const Ul = styled.ul<{ open: boolean }>`
   left: 0;
   background-color: ${T.colors.dark};
   transition: all 0.25s;
-  top: -100%;
+  top: -300%;
   padding-bottom: 1rem;
   z-index: ${T.layers.topBar};
   opacity: 0;


### PR DESCRIPTION
This PR includes mobile version minor fixes: 
- Hide menu items after navigation 
- Even after hiding the menu, it stays in front of top bar, increasing the menu up movement when hiding to fix it

🚀 